### PR TITLE
API update, size optimization, auto-start

### DIFF
--- a/curl/Dockerfile
+++ b/curl/Dockerfile
@@ -1,7 +1,11 @@
-FROM debian:buster-slim
+# Multi-stage build: First the full builder image:
 
+FROM debian:buster-slim as intermediate
+
+# define the Curl version to be baked in
 ENV CURL_VERSION 7.66.0
 
+# Get all software packages required for builing all components:
 RUN apt-get update -qq \
     && apt-get install -y build-essential \
                           git \
@@ -13,16 +17,19 @@ RUN apt-get update -qq \
                           # misc
                           wget;
 
-# get sources
+# Default location where all binaries wind up:
+ARG INSTALLDIR=/opt/oqssa
+
+# get all sources
 WORKDIR /opt
 RUN git clone --single-branch --branch master https://github.com/open-quantum-safe/liboqs && \
     git clone --single-branch --branch OQS-OpenSSL_1_1_1-stable https://github.com/open-quantum-safe/openssl ossl-src && \
     wget https://curl.haxx.se/download/curl-${CURL_VERSION}.tar.gz && tar -zxvf curl-${CURL_VERSION}.tar.gz;
 
-# build liboqs
+# build liboqs - also shared
 WORKDIR /opt/liboqs
 RUN autoreconf -i && \
-    ./configure --prefix=/opt/ossl-src/oqs --enable-shared=no && \
+    ./configure --prefix=/opt/ossl-src/oqs && \
     make -j && \
     make install;
 
@@ -30,37 +37,75 @@ RUN autoreconf -i && \
 WORKDIR /opt/ossl-src
 # curl looks for shared libraries
 # at ./configure time
-RUN ./config shared --prefix=/opt/openssl && \
-    make && make install_sw;
+RUN LDFLAGS="-Wl,-rpath -Wl,${INSTALLDIR}/lib" ./config shared --prefix=${INSTALLDIR} && \
+    make -j && make install;
 
-# build curl
-WORKDIR /opt/curl-${CURL_VERSION}
-RUN env CPPFLAGS="-I/opt/ossl-src/oqs/include" \
-        ./configure --prefix=/opt/curl \
-                    --enable-debug \
-                    --with-ssl=/opt/openssl && \
-    sed -i 's/EVP_MD_CTX_create/EVP_MD_CTX_new/g; s/EVP_MD_CTX_destroy/EVP_MD_CTX_free/g' lib/vtls/openssl.c && \
-    make && make install;
+# set path to use 'new' openssl & curl. Dyn libs have been properly linked in to match
+ENV PATH="${INSTALLDIR}/bin:${PATH}"
 
-# ensure dynamic linker looks in the
-# right place for libssl and libcrypto
-ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/opt/openssl/lib"
+# generate certificates for openssl s_server, which is what we will test curl against
+ENV OPENSSL=${INSTALLDIR}/bin/openssl
+ENV OPENSSL_CNF=${INSTALLDIR}/ssl/openssl.cnf
 
-# generate certificates for
-# openssl s_server, which is
-# what we will test curl against
-ARG OPENSSL=/opt/openssl/bin/openssl
-ARG OPENSSL_CNF=/opt/ossl-src/apps/openssl.cnf
-
+# Default root CA signature algorithm; can be set to any listed at https://github.com/open-quantum-safe/openssl#authentication
 ARG SIG_ALG="dilithium2"
 
-WORKDIR /opt/openssl/bin
+WORKDIR ${INSTALLDIR}/bin
 RUN set -x && \
     # generate CA key and cert
-    ${OPENSSL} req -x509 -new -newkey ${SIG_ALG} -keyout CA.key -out CA.crt -nodes -subj "/CN=oqstest CA" -days 365 -config ${OPENSSL_CNF} && \
-    # generate server CSR
-    ${OPENSSL} req -new -newkey ${SIG_ALG} -keyout /server.key -out server.csr -nodes -subj "/CN=oqstest CA" -config ${OPENSSL_CNF} && \
-    # generate server cert
-    ${OPENSSL} x509 -req -in server.csr -out /server.crt -CA CA.crt -CAkey CA.key -CAcreateserial -days 365;
+    ${OPENSSL} req -x509 -new -newkey ${SIG_ALG} -keyout CA.key -out CA.crt -nodes -subj "/CN=oqstest CA" -days 365 -config ${OPENSSL_CNF} 
+
+# build curl - injecting OQS CA generated above into root store
+WORKDIR /opt/curl-${CURL_VERSION}
+RUN env CPPFLAGS="-I/opt/ossl-src/oqs/include" \
+        LDFLAGS=-Wl,-R${INSTALLDIR}/lib  \
+        ./configure --prefix=${INSTALLDIR} \
+                    --enable-debug \
+                    --with-ca-bundle=${INSTALLDIR}/bin/CA.crt \
+                    --with-ssl=${INSTALLDIR} && \
+    make -j && make install;
 
 WORKDIR /
+
+COPY serverstart.sh ${INSTALLDIR}/bin
+
+CMD ["serverstart.sh"]
+
+# second stage: Only create minimal image without build tooling and intermediate build results generated above:
+FROM debian:buster-slim
+
+RUN apt-get update -qq 
+
+# Default root CA signature algorithm; can be set to any listed at https://github.com/open-quantum-safe/openssl#authentication
+ARG SIG_ALG="dilithium2"
+
+# Default location where all binaries wind up:
+ARG INSTALLDIR=/opt/oqssa
+
+# Only retain the ${INSTALLDIR} contents in the final image
+COPY --from=intermediate ${INSTALLDIR} ${INSTALLDIR}
+
+# set path to use 'new' openssl & curl. Dyn libs have been properly linked in to match
+ENV PATH="${INSTALLDIR}/bin:${PATH}"
+
+# generate certificates for openssl s_server, which is what we will test curl against
+ENV OPENSSL=${INSTALLDIR}/bin/openssl
+ENV OPENSSL_CNF=${INSTALLDIR}/ssl/openssl.cnf
+
+WORKDIR ${INSTALLDIR}/bin
+
+RUN set -x && \
+    # generate server CSR using pre-set CA.key & cert
+    ${OPENSSL} req -new -newkey ${SIG_ALG} -keyout /server.key -out /server.csr -nodes -subj "/CN=localhost" -config ${OPENSSL_CNF} && \
+    # generate server cert
+    ${OPENSSL} x509 -req -in /server.csr -out /server.crt -CA CA.crt -CAkey CA.key -CAcreateserial -days 365;
+
+WORKDIR /
+
+COPY serverstart.sh ${INSTALLDIR}/bin
+
+# Enable a normal user to create new server keys off set CA
+RUN useradd -ms /bin/bash oqs && chown oqs.oqs /server.* && chmod go+r ${INSTALLDIR}/bin/CA.key && chmod go+w ${INSTALLDIR}/bin/CA.srl
+
+USER oqs
+CMD ["serverstart.sh"]

--- a/curl/README.md
+++ b/curl/README.md
@@ -1,9 +1,37 @@
 This directory contains a Dockerfile that builds curl with the [OQS OpenSSL 1.1.1 fork](https://github.com/open-quantum-safe/openssl), which allows curl to negotiate quantum-safe keys and use quantum-safe authentication in TLS 1.3.
 
-To get started, install Docker and build the image by running `docker build --build-arg SIG_ALG=<SIG> --tag oqs-curl-img .` (`<SIG>` can be any of the authentication algorithms listed [here](https://github.com/open-quantum-safe/openssl#supported-algorithms)). Then, in order to verify that the curl so built is capable of using quantum-safe cryptography:
+## Quick start
 
-1. Enter the container by running `docker run -it --entrypoint=/bin/bash oqs-curl-img`.
+1) Be sure to have [docker installed](https://docs.docker.com/install).
+2) Run `docker build -t oqs-curl .` to create a post quantum-enabled OpenSSL and Curl docker image
+3) To verify all components perform quantum-safe operations, first start the container with `docker run -it oqs-curl` thus starting an OQS-enabled TLS test server.
+4) On the command prompt in the docker container query that server using `curl https://localhost:4433`. If all works, the last command returns all TLS information documenting use of OQS-enabled TLS.
 
-2. Run `/opt/openssl/bin/openssl s_server -cert server.crt -key -server.key -curves <KEX> -www -tls1_3 -accept localhost:4433 &`, where `<KEX>` is a colon-separated list containing any key exchange algorithm listed [here](https://github.com/open-quantum-safe/openssl#supported-algorithms). This starts a basic, post-quantum aware HTTPS web-server.
 
-3. Finally, retrieve a web-page from this server over TLS 1.3 using curl as follows: `/opt/curl/bin/curl --insecure https://localhost:4433/index.html` (the `--insecure` flag is necessary as `s_server` uses self-signed certificates).
+## More details
+
+The Dockerfile 
+- obtains all source code required for building the quantum-safe crypto (QSC) algorithms, the QSC-enabled version of OpenSSL (v.1.1.1), curl (v.7.66.0) 
+- builds all libraries and applications
+- creates OQS-enabled certificate files for a mini-root certificate authority (CA) 
+- creates an OQS-enabled server certificate for running a `localhost` QSC-TLS server
+- by default starts an openssl (s_server) based test server.
+
+The signature algorithm for the certificates is set to `dilithium2` by default, but can be changed to any of the [supported OQS signature algorithms](https://github.com/open-quantum-safe/openssl#authentication) with the build argumemt to docker `--build-arg SIG_ALG=`*name-of-oqs-sig-algorithm*, e.g. as follows:
+```
+docker build -t oqs-curl --build-arg SIG_ALG=qteslapiii .
+```
+
+**Note for the interested**: The build process is two-stage with the final image only retaining all executables, libraries and include-files to utilize OQS-enabled curl and openssl.
+
+Two further, runtime configuration option exist that can both be optionally set via docker environment variables:
+
+1) Setting the key exchange mechanism (KEM): By setting 'KEM_ALG' 
+to any of the [supported KEM algorithms built into OQS-OpenSSL](https://github.com/open-quantum-safe/openssl#key-exchange) one can run TLS using a KEM other than the default algorithm 'kyber512'. Example: `docker run -e KEM_ALG=newhope1024cca -it oqs-curl`. 
+
+2) Setting the signature algorithm (SIG): By setting 'SIG_ALG' to any of the [supported OQS signature algorithms](https://github.com/open-quantum-safe/openssl#authentication) one can run TLS using a SIG other than the one set when building the image (see above). Example: `docker run -e SIG_ALG=picnicl1fs -it oqs-curl`.
+
+## Easter egg
+
+The docker image can also be used to execute performance tests against the different OQS algoritms: Simply start the image as shown above and then execute the standard OpenSSL handshake performance test like this `openssl s_time -connect :4433`. Be sure to first define the algorithms you are interested in, e.g., `docker run -e KEM_ALG=sikep751 -e SIG_ALG=picnicl1fs -it oqs-curl`.
+

--- a/curl/serverstart.sh
+++ b/curl/serverstart.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Optionally set KEM to one defined in https://github.com/open-quantum-safe/openssl#key-exchange
+if [ "x$KEM_ALG" == "x" ]; then
+	export KEM_ALG=kyber512
+fi
+
+# Optionally set server certificate alg to one defined in https://github.com/open-quantum-safe/openssl#authentication
+# The root CA's signature alg remains as set when building the image
+if [ "x$SIG_ALG" != "x" ]; then
+    cd /opt/oqssa/bin
+    # generate new server CSR using pre-set CA.key & cert
+    openssl req -new -newkey $SIG_ALG -keyout /server.key -out /server.csr -nodes -subj "/CN=localhost" 
+    # generate server cert
+    openssl x509 -req -in /server.csr -out /server.crt -CA CA.crt -CAkey CA.key -CAcreateserial -days 365
+fi
+
+# Start a TLS1.3 test server based on OpenSSL accepting only the specified KEM_ALG
+openssl s_server -cert /server.crt -key /server.key -curves $KEM_ALG -www -tls1_3 -accept localhost:4433&
+
+# Open a shell for local experimentation
+bash


### PR DESCRIPTION
This updates the curl build
- to the standard openssl APIs
- creating run-time SIG_ALG, KEM_ALG parameterisation
- reducing its size considerably
- eliminating the need for '--insecure' communication
- automating its use
- enhancing the documentation
- enabling performance testing [addressing an OQS-openssl issue](https://github.com/open-quantum-safe/openssl/issues/10)
- making it easier to deploy in "secured" K8S clusters (non-root user)